### PR TITLE
AIRO-1486: Destroy vhacd instance

### DIFF
--- a/VHACD.cs
+++ b/VHACD.cs
@@ -184,6 +184,8 @@ namespace MeshProcess
                 
                 convexMesh.Add(hullMesh);
             }
+
+            DestroyVHACD(vhacd);
             return convexMesh;
         }
     }


### PR DESCRIPTION
## Proposed change(s)

Destroy `vhacd` instance to prevent memory leak.

### Useful links (GitHub issues, JIRA tickets, forum threads, etc.)

#5 

### Types of change(s)

- [x] Bug fix